### PR TITLE
Invert error structure

### DIFF
--- a/src/phase0/state_transition/block_processing.rs
+++ b/src/phase0/state_transition/block_processing.rs
@@ -5,7 +5,7 @@ use crate::phase0::operations::{
     Attestation, AttesterSlashing, Deposit, ProposerSlashing, SignedVoluntaryExit,
 };
 use crate::phase0::state_transition::{
-    get_beacon_proposer_index, invalid_header_error, invalid_opearation_error, Context, Error,
+    get_beacon_proposer_index, invalid_header_error, invalid_operation_error, Context, Error,
     InvalidBeaconBlockHeader, InvalidDeposit, InvalidOperation,
 };
 use ssz_rs::prelude::*;
@@ -348,7 +348,7 @@ fn process_operations<
     );
 
     if body.deposits.len() != expected_deposit_count {
-        return Err(invalid_opearation_error(InvalidOperation::Deposit(
+        return Err(invalid_operation_error(InvalidOperation::Deposit(
             InvalidDeposit::IncorrectCount {
                 expected: expected_deposit_count,
                 count: body.deposits.len(),

--- a/src/phase0/state_transition/block_processing.rs
+++ b/src/phase0/state_transition/block_processing.rs
@@ -5,8 +5,8 @@ use crate::phase0::operations::{
     Attestation, AttesterSlashing, Deposit, ProposerSlashing, SignedVoluntaryExit,
 };
 use crate::phase0::state_transition::{
-    get_beacon_proposer_index, Context, Error, InvalidBeaconBlockHeader, InvalidDeposit,
-    InvalidOperation,
+    get_beacon_proposer_index, invalid_header_error, invalid_opearation_error, Context, Error,
+    InvalidBeaconBlockHeader, InvalidDeposit, InvalidOperation,
 };
 use ssz_rs::prelude::*;
 
@@ -176,41 +176,41 @@ fn process_block_header<
     context: &Context,
 ) -> Result<(), Error> {
     if block.slot != state.slot {
-        return Err(Error::InvalidOperation(InvalidOperation::Header(
+        return Err(invalid_header_error(
             InvalidBeaconBlockHeader::StateSlotMismatch {
                 state_slot: state.slot,
                 block_slot: block.slot,
             },
-        )));
+        ));
     }
 
     if block.slot <= state.latest_block_header.slot {
-        return Err(Error::InvalidOperation(InvalidOperation::Header(
+        return Err(invalid_header_error(
             InvalidBeaconBlockHeader::OlderThanLatestBlockHeader {
                 block_slot: block.slot,
                 latest_block_header_slot: state.latest_block_header.slot,
             },
-        )));
+        ));
     }
 
     let proposer_index = get_beacon_proposer_index(state, context)?;
     if block.proposer_index != proposer_index {
-        return Err(Error::InvalidOperation(InvalidOperation::Header(
+        return Err(invalid_header_error(
             InvalidBeaconBlockHeader::ProposerIndexMismatch {
                 block_proposer_index: block.proposer_index,
                 state_proposer_index: proposer_index,
             },
-        )));
+        ));
     }
 
     let expected_parent_root = state.latest_block_header.hash_tree_root()?;
     if block.parent_root != expected_parent_root {
-        return Err(Error::InvalidOperation(InvalidOperation::Header(
+        return Err(invalid_header_error(
             InvalidBeaconBlockHeader::ParentBlockRootMismatch {
                 expected: expected_parent_root,
                 provided: block.parent_root,
             },
-        )));
+        ));
     }
 
     state.latest_block_header = BeaconBlockHeader {
@@ -223,9 +223,9 @@ fn process_block_header<
 
     let proposer = &state.validators[block.proposer_index];
     if proposer.slashed {
-        return Err(Error::InvalidOperation(InvalidOperation::Header(
+        return Err(invalid_header_error(
             InvalidBeaconBlockHeader::ProposerSlashed(proposer_index),
-        )));
+        ));
     }
 
     Ok(())
@@ -348,7 +348,7 @@ fn process_operations<
     );
 
     if body.deposits.len() != expected_deposit_count {
-        return Err(Error::InvalidOperation(InvalidOperation::Deposit(
+        return Err(invalid_opearation_error(InvalidOperation::Deposit(
             InvalidDeposit::IncorrectCount {
                 expected: expected_deposit_count,
                 count: body.deposits.len(),

--- a/src/phase0/state_transition/epoch_processing.rs
+++ b/src/phase0/state_transition/epoch_processing.rs
@@ -186,12 +186,9 @@ pub fn process_slashings<
         state.slashings.iter().sum::<Gwei>() * context.proportional_slashing_multiplier,
         total_balance,
     );
-    // TODO: refactor expensive copy
-    // Used due to issue with borrowing & immutable / mutable references
-    let s = state.clone();
-    let validators = s.validators.iter().enumerate();
+    let validators = state.validators.clone();
 
-    for (index, validator) in validators {
+    for (index, validator) in validators.iter().enumerate() {
         if validator.slashed
             && (epoch + context.epochs_per_slashings_vector as u64 / 2)
                 == validator.withdrawable_epoch

--- a/src/phase0/state_transition/epoch_processing.rs
+++ b/src/phase0/state_transition/epoch_processing.rs
@@ -1,9 +1,10 @@
 use crate::phase0::beacon_state::BeaconState;
 use crate::phase0::operations::PendingAttestation;
 use crate::phase0::state_transition::{
-    get_block_root, get_current_epoch, get_previous_epoch, get_randao_mix, Context, Error,
+    decrease_balance, get_block_root, get_current_epoch, get_previous_epoch, get_randao_mix,
+    get_total_active_balance, Context, Error,
 };
-use crate::primitives::Epoch;
+use crate::primitives::{Epoch, Gwei};
 use ssz_rs::prelude::*;
 
 pub fn get_matching_source_attestations<
@@ -167,7 +168,7 @@ pub fn process_slashings<
     const MAX_VALIDATORS_PER_COMMITTEE: usize,
     const PENDING_ATTESTATIONS_BOUND: usize,
 >(
-    _state: &mut BeaconState<
+    state: &mut BeaconState<
         SLOTS_PER_HISTORICAL_ROOT,
         HISTORICAL_ROOTS_LIMIT,
         ETH1_DATA_VOTES_BOUND,
@@ -177,8 +178,32 @@ pub fn process_slashings<
         MAX_VALIDATORS_PER_COMMITTEE,
         PENDING_ATTESTATIONS_BOUND,
     >,
-    _context: &Context,
+    context: &Context,
 ) -> Result<(), Error> {
+    let epoch = get_current_epoch(state, context);
+    let total_balance = get_total_active_balance(state, context)?;
+    let adjusted_total_slashing_balance = Gwei::min(
+        state.slashings.iter().sum::<Gwei>() * context.proportional_slashing_multiplier,
+        total_balance,
+    );
+    // TODO: refactor expensive copy
+    // Used due to issue with borrowing & immutable / mutable references
+    let s = state.clone();
+    let validators = s.validators.iter().enumerate();
+
+    for (index, validator) in validators {
+        if validator.slashed
+            && (epoch + context.epochs_per_slashings_vector as u64 / 2)
+                == validator.withdrawable_epoch
+        {
+            let increment = context.effective_balance_increment;
+            let penalty_numerator =
+                validator.effective_balance / increment * adjusted_total_slashing_balance;
+            let penalty = penalty_numerator / total_balance * increment;
+            decrease_balance(state, index, penalty);
+        }
+    }
+
     Ok(())
 }
 

--- a/src/phase0/state_transition/epoch_processing.rs
+++ b/src/phase0/state_transition/epoch_processing.rs
@@ -186,9 +186,9 @@ pub fn process_slashings<
         state.slashings.iter().sum::<Gwei>() * context.proportional_slashing_multiplier,
         total_balance,
     );
-    let validators = state.validators.clone();
 
-    for (index, validator) in validators.iter().enumerate() {
+    for i in 0..state.validators.len() {
+        let validator = &state.validators[i];
         if validator.slashed
             && (epoch + context.epochs_per_slashings_vector as u64 / 2)
                 == validator.withdrawable_epoch
@@ -197,7 +197,7 @@ pub fn process_slashings<
             let penalty_numerator =
                 validator.effective_balance / increment * adjusted_total_slashing_balance;
             let penalty = penalty_numerator / total_balance * increment;
-            decrease_balance(state, index, penalty);
+            decrease_balance(state, i, penalty);
         }
     }
 

--- a/src/phase0/state_transition/mod.rs
+++ b/src/phase0/state_transition/mod.rs
@@ -129,7 +129,7 @@ pub fn invalid_header_error(error: InvalidBeaconBlockHeader) -> Error {
     Error::InvalidBlock(InvalidBlock::Header(error))
 }
 
-pub fn invalid_opearation_error(error: InvalidOperation) -> Error {
+pub fn invalid_operation_error(error: InvalidOperation) -> Error {
     Error::InvalidBlock(InvalidBlock::InvalidOperation(error))
 }
 
@@ -207,7 +207,7 @@ pub fn is_valid_indexed_attestation<
     let attesting_indices = &indexed_attestation.attesting_indices;
 
     if attesting_indices.is_empty() {
-        return Err(invalid_opearation_error(
+        return Err(invalid_operation_error(
             InvalidOperation::IndexedAttestation(InvalidIndexedAttestation::AttestingIndicesEmpty),
         ));
     }
@@ -221,7 +221,7 @@ pub fn is_valid_indexed_attestation<
         })
         .all(|x| x);
     if !is_sorted {
-        return Err(invalid_opearation_error(
+        return Err(invalid_operation_error(
             InvalidOperation::IndexedAttestation(
                 InvalidIndexedAttestation::AttestingIndicesNotSorted,
             ),
@@ -239,7 +239,7 @@ pub fn is_valid_indexed_attestation<
                 seen.insert(i);
             }
         }
-        return Err(invalid_opearation_error(
+        return Err(invalid_operation_error(
             InvalidOperation::IndexedAttestation(InvalidIndexedAttestation::DuplicateIndices(
                 duplicates,
             )),
@@ -997,7 +997,7 @@ pub fn get_attesting_indices<
     let committee = get_beacon_committee(state, data.slot, data.index, context)?;
 
     if bits.len() != committee.len() {
-        return Err(invalid_opearation_error(InvalidOperation::Attestation(
+        return Err(invalid_operation_error(InvalidOperation::Attestation(
             InvalidAttestation::Bitfield {
                 expected_length: committee.len(),
                 length: bits.len(),


### PR DESCRIPTION
Could also do
```rust
pub fn invalid_operation_error(error: InvalidOperation) -> Result<(), Error> {
    Err(Error::InvalidBlock(InvalidBlock::InvalidOperation(error)))
}
```
instead of
```rust
pub fn invalid_operation_error(error: InvalidOperation) -> Error {
    Error::InvalidBlock(InvalidBlock::InvalidOperation(error))
}
```
and then in code write
```rust
return invalid_opearation_error(...);
```
insteaf of 
```rust
return Err(invalid_opearation_error(...));
```
but not every function returns `Result<(), Error>` (for example `get_attesting_indices` returns `Result<HashSet<ValidatorIndex>, Error>`)